### PR TITLE
feat: Add context allowlist configuration with CLI flag and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 dev.log.yaml
+.aider*
+mcp-k8s-go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md - MCP K8S Go Development Guide
+
+## Build & Test Commands
+- Build: `go build`
+- Run with hot reload: `arelo -p '**/*.go' -i '**/.*' -i '**/*_test.go' -- go run main.go`
+- Run all tests: `go test`
+- Run single test: `go test -run '^TestName$'` (example: `go test -run '^TestListContexts$'`)
+- Generate mocks: `tools/generate-mocks.sh`
+- Lint: `golangci-lint run`
+
+## Code Style Guidelines
+- **Imports**: Standard Go import organization (stdlib, external, internal)
+- **Error Handling**: Return errors explicitly; prefer wrapping with context
+- **Naming**: Use Go conventions (CamelCase for exported, camelCase for unexported)
+- **Testing**: Use YAML test files in testdata directory with foxytest package
+- **Types**: Use strong typing; prefer interfaces for dependencies
+- **Documentation**: Document all exported functions and types
+- **Structure**: Follow k8s-like API structure in internal/k8s package
+- **Dependencies**: Use dependency injection with fx framework
+- **Context**: Pass kubernetes contexts explicitly as parameters

--- a/README.md
+++ b/README.md
@@ -163,11 +163,17 @@ Now you should be able to run Claude Desktop and:
 - ask Claude to list events in a given context and namespace
 - ask Claude to read logs of a given pod in a given context and namespace
 
-### Environment Variables
+### Environment Variables and Command-line Options
 
 The following environment variables are used by the MCP server:
 
 - `KUBECONFIG`: Path to your Kubernetes configuration file (optional, defaults to ~/.kube/config)
+
+The following command-line options are supported:
+
+- `--allowed-contexts=<ctx1,ctx2,...>`: Comma-separated list of allowed Kubernetes contexts that users can access. If not specified, all contexts are allowed.
+- `--help`: Display help information
+- `--version`: Display version information
 
 ## Contributing
 

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"flag"
+	"strings"
+)
+
+// Options represents the global configuration options
+type Options struct {
+	// AllowedContexts is a list of k8s contexts that users are allowed to access
+	// If empty, all contexts are allowed
+	AllowedContexts []string
+}
+
+// GlobalOptions contains the parsed command line options
+var GlobalOptions = &Options{}
+
+// ParseFlags parses the command line flags
+func ParseFlags() bool {
+	var allowedContextsStr string
+	flag.StringVar(&allowedContextsStr, "allowed-contexts", "", "Comma-separated list of allowed k8s contexts. If empty, all contexts are allowed")
+	
+	// Add other flags here
+
+	// Parse the flags
+	flag.Parse()
+
+	// Check if the flag is --version, version, help or --help
+	// If so, we don't need to continue processing
+	if len(flag.Args()) > 0 {
+		arg := flag.Args()[0]
+		if arg == "--version" || arg == "version" || arg == "help" || arg == "--help" {
+			return false
+		}
+	}
+
+	// Process allowed contexts
+	if allowedContextsStr != "" {
+		GlobalOptions.AllowedContexts = strings.Split(allowedContextsStr, ",")
+		for i, ctx := range GlobalOptions.AllowedContexts {
+			GlobalOptions.AllowedContexts[i] = strings.TrimSpace(ctx)
+		}
+	}
+
+	return true
+}
+
+// IsContextAllowed checks if a context is allowed based on the configuration
+func IsContextAllowed(contextName string) bool {
+	// If the allowed contexts list is empty, all contexts are allowed
+	if len(GlobalOptions.AllowedContexts) == 0 {
+		return true
+	}
+	
+	for _, allowed := range GlobalOptions.AllowedContexts {
+		if allowed == contextName {
+			return true
+		}
+	}
+	
+	return false
+}

--- a/internal/config/options_test.go
+++ b/internal/config/options_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestIsContextAllowed(t *testing.T) {
+	// Reset the global options between tests
+	defer func() {
+		GlobalOptions = &Options{}
+	}()
+
+	tests := []struct {
+		name           string
+		allowedContexts []string
+		contextName    string
+		expected       bool
+	}{
+		{
+			name:           "all contexts allowed when no restrictions",
+			allowedContexts: []string{},
+			contextName:    "any-context",
+			expected:       true,
+		},
+		{
+			name:           "context explicitly allowed",
+			allowedContexts: []string{"context-1", "context-2"},
+			contextName:    "context-1",
+			expected:       true,
+		},
+		{
+			name:           "context not allowed",
+			allowedContexts: []string{"context-1", "context-2"},
+			contextName:    "context-3",
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			GlobalOptions.AllowedContexts = tt.allowedContexts
+
+			// Test
+			result := IsContextAllowed(tt.contextName)
+
+			// Verify
+			if result != tt.expected {
+				t.Errorf("IsContextAllowed(%q) = %v, want %v", 
+					tt.contextName, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"github.com/strowk/mcp-k8s-go/internal/config"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -48,4 +49,9 @@ func GetKubeClientset() (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 	return clientset, nil
+}
+
+// IsContextAllowed checks if a context is allowed based on the configuration
+func IsContextAllowed(contextName string) bool {
+	return config.IsContextAllowed(contextName)
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/strowk/mcp-k8s-go/internal/config"
 	"github.com/strowk/mcp-k8s-go/internal/k8s"
 	"github.com/strowk/mcp-k8s-go/internal/prompts"
 	"github.com/strowk/mcp-k8s-go/internal/resources"
@@ -41,24 +42,26 @@ var (
 
 func main() {
 	if len(os.Args) > 1 {
-		if os.Args[1] == "--version" {
+		arg := os.Args[1]
+		if arg == "--version" {
 			println(version)
+			return
 		}
-		if os.Args[1] == "version" {
+		if arg == "version" {
 			println("Version: ", version)
 			println("Commit: ", commit)
 			println("Date: ", date)
+			return
 		}
-		if os.Args[1] == "help" || os.Args[1] == "--help" {
-			println("mcp-k8s is an MCP server for Kubernetes")
-			println("Read more about it in: https://github.com/strowk/mcp-k8s-go\n")
-			println("Usage: <bin> [flags]")
-			println("  Run with no flags to start the server\n")
-			println("Flags:")
-			println("  help, --help: Print this help message")
-			println("  --version: Print the version of the server")
-			println("  version: Print the version, commit and date of the server")
+		if arg == "help" || arg == "--help" {
+			printHelp()
+			return
 		}
+	}
+
+	// Parse configuration flags
+	shouldContinue := config.ParseFlags()
+	if !shouldContinue {
 		return
 	}
 
@@ -67,6 +70,19 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}
+}
+
+func printHelp() {
+	println("mcp-k8s is an MCP server for Kubernetes")
+	println("Read more about it in: https://github.com/strowk/mcp-k8s-go\n")
+	println("Usage: <bin> [flags]")
+	println("  Run with no flags to start the server\n")
+	println("Flags:")
+	println("  help, --help: Print this help message")
+	println("  --version: Print the version of the server")
+	println("  version: Print the version, commit and date of the server")
+	println("  --allowed-contexts=<ctx1,ctx2,...>: Comma-separated list of allowed k8s contexts")
+	println("      If not specified, all contexts are allowed")
 }
 
 func getApp() *app.Builder {

--- a/main_test.go
+++ b/main_test.go
@@ -28,6 +28,19 @@ func TestListContexts(t *testing.T) {
 	ts.AssertNoErrors(cntrl)
 }
 
+func TestWithAllowedContexts(t *testing.T) {
+	ts, err := foxytest.Read("testdata/with_k8s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Setenv("KUBECONFIG", "./testdata/k8s_contexts/kubeconfig")
+	defer os.Unsetenv("KUBECONFIG")
+	ts.WithExecutable("go", []string{"run", "main.go", "--allowed-contexts=allowed-ctx"})
+	cntrl := foxytest.NewTestRunner(t)
+	ts.Run(cntrl)
+	ts.AssertNoErrors(cntrl)
+}
+
 func TestLists(t *testing.T) {
 	ts, err := foxytest.Read("testdata")
 	if err != nil {

--- a/testdata/with_k8s/allowed_contexts_test.yaml
+++ b/testdata/with_k8s/allowed_contexts_test.yaml
@@ -1,0 +1,74 @@
+case: List namespaces with disallowed context
+in:
+  {
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 2,
+    "params":
+      {
+        "name": "list-k8s-namespaces",
+        "arguments": { "context": "disallowed-ctx" }
+      }
+  }
+out:
+  {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result":
+      {
+        "content": [{"type": "text", "text": "context disallowed-ctx is not allowed"}],
+        "isError": true
+      }
+  }
+
+---
+case: List k8s resources with disallowed context
+in:
+  {
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 3,
+    "params":
+      {
+        "name": "list-k8s-resources",
+        "arguments": { "context": "disallowed-ctx", "kind": "pod", "namespace": "default" }
+      }
+  }
+out:
+  {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "result":
+      {
+        "content": [{"type": "text", "text": "context disallowed-ctx is not allowed"}],
+        "isError": true
+      }
+  }
+
+---
+case: Get pod logs with disallowed context
+in:
+  {
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "id": 4,
+    "params":
+      {
+        "name": "get-k8s-pod-logs",
+        "arguments": { 
+          "context": "disallowed-ctx",
+          "namespace": "default",
+          "pod": "example-pod"
+        }
+      }
+  }
+out:
+  {
+    "jsonrpc": "2.0",
+    "id": 4,
+    "result":
+      {
+        "content": [{"type": "text", "text": "context disallowed-ctx is not allowed"}],
+        "isError": true
+      }
+  }


### PR DESCRIPTION
Thanks  a lot for this project !  🙌

I wanted to restrict K8s context access easily, this PR:
- Introduces a new argument: --allowed-contexts=<ctx1,ctx2,...>
- Updates config parsing and enforces restrictions across components
- Adds unit tests and updates docs