### PR TITLE
feat: be able to use

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/fx/fxevent"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/tools/clientcmd"
 )
 


### PR DESCRIPTION
This commit fixes the error with "No Auth Provider found for name 'oidc' by importing "k8s.io/client-go/plugin/pkg/client/auth/oidc".

https://github.com/kubernetes/client-go/issues/345 is a relevant issue.