### PR TITLE
execute command in pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,12 +30,15 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +37,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -50,6 +54,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -57,6 +63,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=

--- a/internal/tools/pod_exec_cmd.go
+++ b/internal/tools/pod_exec_cmd.go
@@ -1,0 +1,136 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/strowk/mcp-k8s-go/internal/k8s"
+	"github.com/strowk/mcp-k8s-go/internal/utils"
+
+	"github.com/strowk/foxy-contexts/pkg/fxctx"
+	"github.com/strowk/foxy-contexts/pkg/mcp"
+	"github.com/strowk/foxy-contexts/pkg/toolinput"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func NewPodExecCommandTool(pool k8s.ClientPool) fxctx.Tool {
+	k8sNamespace := "namespace"
+	k8sPodName := "podName"
+	execCommand := "command"
+	k8sContext := "context"
+	schema := toolinput.NewToolInputSchema(
+		toolinput.WithRequiredString(k8sNamespace, "The name of the namespace where the pod to execute the command is located."),
+		toolinput.WithRequiredString(k8sPodName, "The name of the pod in which the command needs to be executed."),
+		toolinput.WithRequiredString(execCommand, "The command to be executed inside the pod."),
+		toolinput.WithString(k8sContext, "Kubernetes context name."),
+	)
+	return fxctx.NewTool(
+		&mcp.Tool{
+			Name:        "k8s-pod-exec",
+			Description: utils.Ptr("Execute command in Kubernetes pod"),
+			InputSchema: schema.GetMcpToolInputSchema(),
+		},
+		func(args map[string]interface{}) *mcp.CallToolResult {
+			input, err := schema.Validate(args)
+			if err != nil {
+				return errResponse(err)
+			}
+			k8sNamespace, err := input.String(k8sNamespace)
+			if err != nil {
+				return errResponse(fmt.Errorf("invalid input namespace: %w", err))
+			}
+			k8sPodName, err := input.String(k8sPodName)
+			if err != nil {
+				return errResponse(fmt.Errorf("invalid input pod: %w", err))
+			}
+			execCommand, err := input.String(execCommand)
+			if err != nil {
+				return errResponse(fmt.Errorf("invalid input command: %w", err))
+			}
+			k8sContext := input.StringOr(k8sContext, "default")
+
+			kubeconfig := k8s.GetKubeConfigForContext(k8sContext)
+			config, err := kubeconfig.ClientConfig()
+			if err != nil {
+				return errResponse(fmt.Errorf("invalid config: %w", err))
+			}
+			execResult, err := cmdExecuter(pool, config, k8sPodName, k8sNamespace, execCommand, k8sContext)
+			if err != nil {
+				return errResponse(fmt.Errorf("command execute failed: %w", err))
+			}
+
+			var content mcp.TextContent
+			contents := []interface{}{}
+			content, err = NewJsonContent(execResult)
+			if err != nil {
+				return errResponse(err)
+			}
+			contents = append(contents, content)
+
+			return &mcp.CallToolResult{
+				Meta:    map[string]interface{}{},
+				Content: contents,
+				IsError: utils.Ptr(false),
+			}
+		},
+	)
+}
+
+type ExecResult struct {
+	Stdout interface{} `json:"stdout"`
+	Stderr interface{} `json:"stderr"`
+}
+
+func cmdExecuter(pool k8s.ClientPool, config *rest.Config, podName, namespace, cmd, k8sContext string) (ExecResult, error) {
+	execResult := ExecResult{}
+	clientset, err := pool.GetClientset(k8sContext)
+	if err != nil {
+		return execResult, err
+	}
+
+	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return execResult, err
+	}
+
+	if len(pod.Spec.Containers) == 0 {
+		return execResult, fmt.Errorf("Pod %s has no containers", podName)
+	}
+
+	containerName := pod.Spec.Containers[0].Name
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: containerName,
+			Command:   []string{"sh", "-c", cmd},
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+	executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return execResult, err
+	}
+	var stdout, stderr bytes.Buffer
+	if err = executor.Stream(remotecommand.StreamOptions{
+		Stdin:  strings.NewReader(""),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		return execResult, err
+	}
+	execResult.Stdout = stdout.String()
+	execResult.Stderr = stderr.String()
+	return execResult, nil
+}

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func getApp() *app.Builder {
 		WithTool(tools.NewGetResourceTool).
 		WithTool(tools.NewListNodesTool).
 		WithTool(tools.NewListEventsTool).
+		WithTool(tools.NewPodExecCommandTool).
 		WithPrompt(prompts.NewListPodsPrompt).
 		WithPrompt(prompts.NewListNamespacesPrompt).
 		WithResourceProvider(resources.NewContextsResourceProvider).


### PR DESCRIPTION
Executing specific commands inside a pod is a common operation, and it is recommended to add support for it.
Additionally, when the mcphost IP is not within the IP range of the certificate issued by the K8S cluster, a custom kubeconfig file needs to be created with insecure-skip-tls-verify: true configured. Therefore, would it be possible to consider retrieving this setting from an environment variable?